### PR TITLE
The FAQ references SqueakSource, which is on its way out.

### DIFF
--- a/FAQ/FAQ.tex
+++ b/FAQ/FAQ.tex
@@ -158,7 +158,7 @@ abstractMethods value: Collection --> an IdentitySet(#remove:ifAbsent: #add: #do
 How do I generate a view of the \ind{AST} of an expression?
 \end{faq}
 \answer
-Load AST from squeaksource.com. Then evaluate:
+Evaluate:
 \begin{code}{}
 (RBParser parseExpression: '3+4') explore
 \end{code}
@@ -239,9 +239,7 @@ Evaluate \ct{TestRunner open}.
 Where can I find the \ind{Refactoring Browser}?
 \end{faq}
 \answer
-Load AST then Refactoring Engine from squeaksource.com:
-\url{http://www.squeaksource.com/AST}
-\url{http://www.squeaksource.com/RefactoringEngine}
+Pharo ships with the Refactoring Engine built in.
 
 \begin{faq}
 How do I register the browser that I want to be the default?


### PR DESCRIPTION
I left the commented-out reference to Vassili Bykov's Regex in place. (Mainly so that someone can put an example there of how to use a regex.)

Otherwise, SMACC is still hosted at SqueakSource as far as I know.
